### PR TITLE
Less zealous matchPattern

### DIFF
--- a/src/markovTextStego.js
+++ b/src/markovTextStego.js
@@ -10,7 +10,7 @@ var MarkovTextStego = function () {
   // Configure options.
   this.lineDelimiter = '!|!'; // MUST NOT HAVE ANY ALPHABETICAL CHARACTERS!
   this.punctuationList = ['.', '.', '.', '.', '.', '.', '.', '.', '?', '!'];
-  this.matchPattern = /([^\W_][\w\.\?\-\\\/\u2019':&]*[^\W_])|[^\W_]|([:;=]\-?['*\(\)\[\]\\\/DdFPp$Ss0OoXx]+)/g;
+  this.matchPattern = /[^";:,.?!…“”‘’„‚«»‹›—–―¿¡\\\s\(\)]+/g;
 
   this.BitField = function (data) {
     var self = this;


### PR DESCRIPTION
The original one was filtering out accented characters, so that corpora written in most non-English languages could not be used. Not knowing what the different components of the regex are supposed to do, I'm offering this simple one, which only filters out punctuation.
